### PR TITLE
Changed Ambee data point type from 'string' to 'enum'

### DIFF
--- a/server/agents/source-agents/ambee/ambee-agent.ts
+++ b/server/agents/source-agents/ambee/ambee-agent.ts
@@ -59,13 +59,13 @@ const AMBEE_API_KEY_SETTNG: AgentSettingMetadata = {
 const POLLEN_LEVEL_DATAPOINT: SourceAgentDataPointMetadata = {
   key: 'pollen-level',
   name: 'Pollen Level',
-  type: 'string',
+  type: 'enum',
   values: POLLEN_LEVELS,
 };
 const AIR_QUALITY_DATAPOINT: SourceAgentDataPointMetadata = {
   key: 'air-quality',
   name: 'Air Quality',
-  type: 'string',
+  type: 'enum',
   values: [
     'Good',
     'Moderate',

--- a/server/common/source.ts
+++ b/server/common/source.ts
@@ -51,7 +51,7 @@ export interface SourceAgentDataPointMetadata {
   /** The data point's human readable name. */
   name: string;
   /** The type of the data point. */
-  type: 'string' | 'number' | 'boolean';
+  type: 'string' | 'number' | 'boolean' | 'enum';
   /** Optional enumeration values. */
   values?: string[];
 }


### PR DESCRIPTION
Changed the types of the Ambee data points `pollen-level` and `air-quality` to `enum` because the frontend (`add-rule.component.html` -> `mat-form-field` for Value) doesn't provide any case for type `string`. And also, since it's supposed to be a dropdown of fixed values, it should be an Enum to begin with.