### PR TITLE
Fixed add-rule datapoint selection again

### DIFF
--- a/client/src/app/components/add-rule/add-rule.component.html
+++ b/client/src/app/components/add-rule/add-rule.component.html
@@ -149,29 +149,9 @@
             *ngIf="currentRuleConditionDataType"
           >
             <mat-label>Value</mat-label>
-            <ng-container [ngSwitch]="currentRuleConditionDataType">
-              <input
-                *ngSwitchCase="'number'"
-                [(ngModel)]="currentRuleConditionCompareValue"
-                matInput
-                name="rule-value"
-                required
-                type="number"
-                step="1"
-              />
+            <ng-container [ngSwitch]="true">
               <mat-select
-                *ngSwitchCase="'boolean'"
-                [(ngModel)]="currentRuleConditionCompareValue"
-                matInput
-                name="rule-value"
-                required
-              >
-                <mat-option value="true">Yes</mat-option>
-                <mat-option value="false">No</mat-option>
-              </mat-select>
-
-              <mat-select
-                *ngSwitchCase="'enum'"
+                *ngSwitchCase="currentRuleConditionValues && currentRuleConditionValues.length > 0"
                 [(ngModel)]="currentRuleConditionCompareValue"
                 matInput
                 name="rule-value"
@@ -182,6 +162,33 @@
                   value="{{ value }}"
                   >{{ value }}</mat-option
                 >
+              </mat-select>
+              <input
+                *ngSwitchCase="currentRuleConditionDataType === 'number'"
+                [(ngModel)]="currentRuleConditionCompareValue"
+                matInput
+                name="rule-value"
+                required
+                type="number"
+                step="1"
+              />
+              <input
+                *ngSwitchCase="currentRuleConditionDataType === 'string' && !currentRuleConditionValues"
+                [(ngModel)]="currentRuleConditionCompareValue"
+                matInput
+                name="rule-value"
+                required
+                type="text"
+              />
+              <mat-select
+                *ngSwitchCase="currentRuleConditionDataType === 'boolean'"
+                [(ngModel)]="currentRuleConditionCompareValue"
+                matInput
+                name="rule-value"
+                required
+              >
+                <mat-option value="true">Yes</mat-option>
+                <mat-option value="false">No</mat-option>
               </mat-select>
             </ng-container>
           </mat-form-field>

--- a/client/src/app/components/add-rule/add-rule.component.html
+++ b/client/src/app/components/add-rule/add-rule.component.html
@@ -164,7 +164,7 @@
                 >
               </mat-select>
               <input
-                *ngSwitchCase="currentRuleConditionDataType === 'number'"
+                *ngSwitchCase="currentRuleConditionDataType === 'number' && !currentRuleConditionValues"
                 [(ngModel)]="currentRuleConditionCompareValue"
                 matInput
                 name="rule-value"

--- a/client/src/app/components/add-rule/add-rule.component.ts
+++ b/client/src/app/components/add-rule/add-rule.component.ts
@@ -214,6 +214,8 @@ export class AddRuleComponent implements OnInit {
       this.currentRuleConditionDataPoint = val;
       this.currentRuleConditionComparator = 'eq';
       this.currentRuleConditionDataType = dataPoint.type;
+      this.currentRuleConditionValues = undefined;
+
       if (dataPoint.type === 'boolean') {
         this.lockEquals = true;
         this.currentRuleConditionCompareValue = true;
@@ -221,6 +223,9 @@ export class AddRuleComponent implements OnInit {
         this.lockEquals = true;
         this.currentRuleConditionCompareValue = dataPoint.values[0];
         this.currentRuleConditionValues = dataPoint.values;
+      } else if (dataPoint.type === 'string') {
+        this.lockEquals = true;
+        this.currentRuleConditionCompareValue = '';
       } else {
         this.lockEquals = false;
         this.currentRuleConditionCompareValue = '';


### PR DESCRIPTION
Had to issue a re-fix for datapoint selection in "add-rule".

I changed the datapoint types for the Ambee Source Agent back from 'enum' to 'string' in accordance with rule evaluation logic.

In the `add-rule.component.html` I added another switch case for `currentRuleConditionValues && currentRuleConditionValues.length > 0`. This will handle any value arrays. Don't know why `&& currentRuleConditionValues.length` wasn't enough, but it didn't work, that's why.
I also had to explicitly add `&& !currentRuleConditionValues` to the "string" switch case - otherwise both a dropdown AND an input field would be shown (the cases don't `break`).

In the `add-rule.component.ts` `onDataPointChange()` I reset `this.currentRuleConditionValues` to `undefined` - otherwise when switching from an "string-array"-datatype to a "string"-datatype `this.currentRuleConditionValues` would still be populated and thus the first switch case would be activated.
I also set `this.lockEquals = true` for "string" types since we're not going to use "greater than" or "lower than" for strings.