### PR TITLE
align sample agent with updated interface

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 build
+dist

--- a/src/target-agents/agent.sample.ts
+++ b/src/target-agents/agent.sample.ts
@@ -30,14 +30,16 @@ export class SampleAgent extends TargetAgent {
    *
    * @param {string} identifier
    * @param {string} type
+   * @param {string} action
    * @param {boolean} evaluation
    * @param {Parameters} params Additional parameters
    */
   process(
     identifier: string,
     type: string,
+    action: string,
     evaluation: boolean,
-    params: Parameters
+    params: Object
   ) {
     // Check for missing parameters
     this.ensureRequiredParameters(params);
@@ -48,6 +50,7 @@ export class SampleAgent extends TargetAgent {
    *
    * @param {string} identifier
    * @param {string} type
+   * @param {string} action
    * @param {boolean} evaluation
    * @param {Parameters} params Additional parameters
    * @returns {string[]}‚
@@ -55,8 +58,9 @@ export class SampleAgent extends TargetAgent {
   validate(
     identifier: string,
     type: string,
+    action: string,
     evaluation: boolean,
-    params: Parameters
+    params: Object
   ) {
     return [];
   }


### PR DESCRIPTION
The sample target agent did not correctly implement the updated target agent interface, leading to build errors. Fixed with this commit.
Also, add dist folder to .prettierignore since the built index.js does not conform with prettier rules (and does not need to).