### PR TITLE
fix(google-ads): Align delimiter in validation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -480,13 +480,13 @@ class GoogleAds extends TargetAgent {
         let entitiesToBeChecked = [];
         const errors = [];
         if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_ID) {
-            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdsById(params.customerId, identifier.split(',').map(id => String(id))));
+            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdsById(params.customerId, identifier.split(';').map(id => String(id))));
         }
         else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_LABEL) {
             entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdsByLabel(params.customerId, identifier));
         }
         else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_GROUP_ID) {
-            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdGroupsById(params.customerId, identifier.split(',').map(id => String(id))));
+            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdGroupsById(params.customerId, identifier.split(';').map(id => String(id))));
         }
         else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_GROUP_LABEL) {
             entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdGroupsByLabel(params.customerId, identifier));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "if-this-then-ad",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "if-this-then-ad",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@google/clasp": "^2.4.2",
         "@types/google-apps-script": "^1.0.59",

--- a/src/target-agents/google-ads.ts
+++ b/src/target-agents/google-ads.ts
@@ -167,7 +167,7 @@ export class GoogleAds extends TargetAgent {
       entitiesToBeChecked = entitiesToBeChecked.concat(
         this.getAdsById(
           params.customerId,
-          identifier.split(',').map(id => String(id))
+          identifier.split(';').map(id => String(id))
         )
       );
     } else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_LABEL) {
@@ -178,7 +178,7 @@ export class GoogleAds extends TargetAgent {
       entitiesToBeChecked = entitiesToBeChecked.concat(
         this.getAdGroupsById(
           params.customerId,
-          identifier.split(',').map(id => String(id))
+          identifier.split(';').map(id => String(id))
         )
       );
     } else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_GROUP_LABEL) {


### PR DESCRIPTION
The `validate` method was using a comma (`,`) to split multiple entity IDs, while the `handleToggle` method used a semicolon (`;`). This inconsistency would cause validation to fail for rules targeting multiple IDs.

This commit changes the delimiter in the `validate` method to a semicolon to match the processing logic, ensuring that both validation and execution handle multiple IDs consistently.