### PR TITLE
Feat/add asset groups

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -480,13 +480,13 @@ class GoogleAds extends TargetAgent {
         let entitiesToBeChecked = [];
         const errors = [];
         if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_ID) {
-            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdsById(params.customerId, identifier.split(',').map(id => String(id))));
+            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdsById(params.customerId, identifier.split(';').map(id => String(id))));
         }
         else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_LABEL) {
             entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdsByLabel(params.customerId, identifier));
         }
         else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_GROUP_ID) {
-            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdGroupsById(params.customerId, identifier.split(',').map(id => String(id))));
+            entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdGroupsById(params.customerId, identifier.split(';').map(id => String(id))));
         }
         else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_GROUP_LABEL) {
             entitiesToBeChecked = entitiesToBeChecked.concat(this.getAdGroupsByLabel(params.customerId, identifier));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "if-this-then-ad",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "if-this-then-ad",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@google/clasp": "^2.4.2",
         "@types/google-apps-script": "^1.0.59",

--- a/src/target-agents/google-ads.ts
+++ b/src/target-agents/google-ads.ts
@@ -167,7 +167,7 @@ export class GoogleAds extends TargetAgent {
       entitiesToBeChecked = entitiesToBeChecked.concat(
         this.getAdsById(
           params.customerId,
-          identifier.split(',').map(id => String(id))
+          identifier.split(';').map(id => String(id))
         )
       );
     } else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_LABEL) {
@@ -178,7 +178,7 @@ export class GoogleAds extends TargetAgent {
       entitiesToBeChecked = entitiesToBeChecked.concat(
         this.getAdGroupsById(
           params.customerId,
-          identifier.split(',').map(id => String(id))
+          identifier.split(';').map(id => String(id))
         )
       );
     } else if (type === GOOGLE_ADS_SELECTOR_TYPE.AD_GROUP_LABEL) {


### PR DESCRIPTION
feat(google-ads): Add support for Asset Groups
This commit introduces the functionality to enable and pause Google Ads
Asset Groups:

- Adding `ASSET_GROUP_ID` and `ASSET_GROUP_NAME` to the
  `GOOGLE_ADS_SELECTOR_TYPE` enum.
- Extending the `handleToggle` and `validate` methods to process these
  new selector types.
- Creating new private methods (`getAssetGroupsById`,
  `updateAssetGroupStatusByName`, etc.) to query and mutate the
  `assetGroup` resource via the Google Ads API.

**Note** - Need to update Google Sheets with this type after PR is approved